### PR TITLE
Testing

### DIFF
--- a/pkg/node/api/args.go
+++ b/pkg/node/api/args.go
@@ -72,7 +72,7 @@ var createContainerArgs = graphql.FieldConfigArgument{
 	"id": &graphql.ArgumentConfig{
 		Type: graphql.String,
 	},
-	"image_ref": &graphql.ArgumentConfig{
+	"image": &graphql.ArgumentConfig{
 		Type: graphql.String,
 	},
 	"namespace": &graphql.ArgumentConfig{

--- a/pkg/node/api/fields.go
+++ b/pkg/node/api/fields.go
@@ -52,7 +52,7 @@ var taskType = graphql.NewObject(graphql.ObjectConfig{
 
 // NewImageField creates graphql fields for the image type.
 // The image field accepts the arguments defined by the given FieldConfigArgument and is resolved by the function r.
-func NewImageField(sp node.Service, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
+func NewImageField(sp node.ImageService, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
 	return &graphql.Field{
 		Type:        imageType,
 		Description: "Get image",
@@ -63,7 +63,7 @@ func NewImageField(sp node.Service, r graphql.FieldResolveFn, args graphql.Field
 
 // NewImagesField creates graphql fields for the image list type.
 // The images field accepts the arguments defined by the given FieldConfigArgument and is resolved by the function r.
-func NewImagesField(sp node.Service, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
+func NewImagesField(sp node.ImageService, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
 	return &graphql.Field{
 		Type:        graphql.NewList(imageType),
 		Description: "Get image list",
@@ -74,7 +74,7 @@ func NewImagesField(sp node.Service, r graphql.FieldResolveFn, args graphql.Fiel
 
 // NewContainerField creates graphql fields for the container type.
 // The container field accepts the arguments defined by the given FieldConfigArgument and is resolved by the function r.
-func NewContainerField(sp node.Service, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
+func NewContainerField(sp node.ContainerService, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
 	return &graphql.Field{
 		Type:        containerType,
 		Description: "Get container",
@@ -85,7 +85,7 @@ func NewContainerField(sp node.Service, r graphql.FieldResolveFn, args graphql.F
 
 // NewContainersField creates graphql fields for the container list type.
 // The containers field accepts the arguments defined by the given FieldConfigArgument and is resolved by the function r.
-func NewContainersField(sp node.Service, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
+func NewContainersField(sp node.ContainerService, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
 	return &graphql.Field{
 		Type:        graphql.NewList(containerType),
 		Description: "Get container list",
@@ -96,7 +96,7 @@ func NewContainersField(sp node.Service, r graphql.FieldResolveFn, args graphql.
 
 // NewTaskField creates graphql fields for the task type.
 // The task field accepts the arguments defined by the given FieldConfigArgument and is resolved by the function r.
-func NewTaskField(sp node.Service, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
+func NewTaskField(sp node.TaskService, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
 	return &graphql.Field{
 		Type:        taskType,
 		Description: "Get task",
@@ -107,7 +107,7 @@ func NewTaskField(sp node.Service, r graphql.FieldResolveFn, args graphql.FieldC
 
 // NewTasksField creates graphql fields for the task list type.
 // The tasks field accepts the arguments defined by the given FieldConfigArgument and is resolved by the function r.
-func NewTasksField(sp node.Service, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
+func NewTasksField(sp node.TaskService, r graphql.FieldResolveFn, args graphql.FieldConfigArgument) (field *graphql.Field) {
 	return &graphql.Field{
 		Type:        graphql.NewList(taskType),
 		Description: "Get task list",

--- a/pkg/node/api/resolvers.go
+++ b/pkg/node/api/resolvers.go
@@ -318,16 +318,25 @@ func NewCreateContainerResolver(sp node.ContainerService) graphql.FieldResolveFn
 			containerCreateErr                      error
 		)
 
-		if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
-			return nil, errors.New("invalid request")
+		if p.Args["namespace"] != nil {
+
+			if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
-		if imageName, imageNameValid = p.Args["image_name"].(string); !imageNameValid {
-			return nil, errors.New("invalid request")
+		if p.Args["image_name"] != nil {
+
+			if imageName, imageNameValid = p.Args["image_name"].(string); !imageNameValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
-		if ID, IDValid = p.Args["id"].(string); !IDValid {
-			return nil, errors.New("invalid request")
+		if p.Args["id"] != nil {
+
+			if ID, IDValid = p.Args["id"].(string); !IDValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
 		ctx := namespaces.WithNamespace(context.Background(), namespace)
@@ -350,12 +359,18 @@ func NewCreateTaskResolver(ns node.TaskService) graphql.FieldResolveFn {
 			createTaskErr                    error
 		)
 
-		if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
-			return nil, errors.New("invalid request")
+		if p.Args["namespace"] != nil {
+
+			if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
-		if containerID, containerIDValid = p.Args["container_id"].(string); !containerIDValid {
-			return nil, errors.New("invalid request")
+		if p.Args["container_id"] != nil {
+
+			if containerID, containerIDValid = p.Args["container_id"].(string); !containerIDValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
 		ctx := namespaces.WithNamespace(context.Background(), namespace)
@@ -377,12 +392,18 @@ func NewKillTaskResolver(ns node.TaskService) graphql.FieldResolveFn {
 			killTaskErr                      error
 		)
 
-		if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
-			return nil, errors.New("invalid request")
+		if p.Args["namespace"] != nil {
+
+			if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
-		if containerID, containerIDValid = p.Args["container_id"].(string); !containerIDValid {
-			return nil, errors.New("invalid request")
+		if p.Args["container_id"] != nil {
+
+			if containerID, containerIDValid = p.Args["container_id"].(string); !containerIDValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
 		if killTaskErr = ns.KillTask(namespaces.WithNamespace(context.Background(), namespace), containerID); killTaskErr != nil {
@@ -402,12 +423,18 @@ func NewDeleteImageResolver(ns node.ImageService) graphql.FieldResolveFn {
 			deleteImageErr           error
 		)
 
-		if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
-			return nil, errors.New("invalid request")
+		if p.Args["namespace"] != nil {
+
+			if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
-		if ref, refValid = p.Args["ref"].(string); !refValid {
-			return nil, errors.New("invalid request")
+		if p.Args["ref"] != nil {
+
+			if ref, refValid = p.Args["ref"].(string); !refValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
 		if deleteImageErr = ns.DeleteImage(namespaces.WithNamespace(context.Background(), namespace), ref); deleteImageErr != nil {
@@ -427,12 +454,18 @@ func NewDeleteContainerResolver(ns node.ContainerService) graphql.FieldResolveFn
 			deleteContainerErr      error
 		)
 
-		if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
-			return nil, errors.New("invalid request")
+		if p.Args["namespace"] != nil {
+
+			if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
-		if ID, IDValid = p.Args["id"].(string); !IDValid {
-			return nil, errors.New("invalid request")
+		if p.Args["id"] != nil {
+
+			if ID, IDValid = p.Args["id"].(string); !IDValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
 		if deleteContainerErr = ns.DeleteContainer(namespaces.WithNamespace(context.Background(), namespace), ID); deleteContainerErr != nil {
@@ -453,12 +486,18 @@ func NewDeleteTaskResolver(ns node.TaskService) graphql.FieldResolveFn {
 			deleteTaskErr                    error
 		)
 
-		if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
-			return nil, errors.New("invalid request")
+		if p.Args["namespace"] != nil {
+
+			if namespace, namespaceValid = p.Args["namespace"].(string); !namespaceValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
-		if containerID, containerIDValid = p.Args["container_id"].(string); !containerIDValid {
-			return nil, errors.New("invalid request")
+		if p.Args["container_id"] != nil {
+
+			if containerID, containerIDValid = p.Args["container_id"].(string); !containerIDValid {
+				return nil, errors.New("invalid request")
+			}
 		}
 
 		if exitStatus, deleteTaskErr = ns.DeleteTask(namespaces.WithNamespace(context.Background(), namespace), containerID); deleteTaskErr != nil {

--- a/pkg/node/api/resolvers.go
+++ b/pkg/node/api/resolvers.go
@@ -325,9 +325,9 @@ func NewCreateContainerResolver(sp node.ContainerService) graphql.FieldResolveFn
 			}
 		}
 
-		if p.Args["image_name"] != nil {
+		if p.Args["image"] != nil {
 
-			if imageName, imageNameValid = p.Args["image_name"].(string); !imageNameValid {
+			if imageName, imageNameValid = p.Args["image"].(string); !imageNameValid {
 				return nil, errors.New("invalid request")
 			}
 		}

--- a/pkg/node/api/resolvers.go
+++ b/pkg/node/api/resolvers.go
@@ -296,7 +296,7 @@ func NewCreateImageResolver(svc node.Service) graphql.FieldResolveFn {
 
 		ctx := namespaces.WithNamespace(context.Background(), namespace)
 
-		if image, imagePullErr = svc.CreateImage(ctx, ref); imagePullErr != nil {
+		if image, imagePullErr = svc.PullImage(ctx, ref); imagePullErr != nil {
 			return nil, errors.New("createImage resolver failed to create image: " + ref + " with error:  " + imagePullErr.Error())
 		}
 

--- a/pkg/node/api/resolvers_test.go
+++ b/pkg/node/api/resolvers_test.go
@@ -1,0 +1,486 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/containerd/containerd/cio"
+	"github.com/graphql-go/graphql"
+	"github.com/mokrz/clamor/pkg/node"
+	"github.com/mokrz/clamor/pkg/node/api"
+)
+
+type image struct {
+	name string
+}
+
+func NewImage(n string) node.Image {
+	return &image{name: n}
+}
+
+func (i *image) Name() string {
+	return i.name
+}
+
+type imageSvc struct {
+	images map[string]node.Image
+}
+
+func NewImageService(seedImages map[string]node.Image) node.ImageService {
+	return &imageSvc{
+		images: seedImages,
+	}
+}
+
+func (is *imageSvc) PullImage(ctx context.Context, name string) (image node.Image, err error) {
+	image = NewImage(name)
+	is.images[name] = image
+	return image, nil
+}
+
+func (is *imageSvc) GetImage(ctx context.Context, name string) (image node.Image, err error) {
+	var imageValid bool
+
+	if image, imageValid = is.images[name]; !imageValid {
+		return nil, errors.New("invalid image")
+	}
+
+	return image, nil
+}
+
+func (is *imageSvc) GetImages(ctx context.Context, filter string) (images []node.Image, err error) {
+
+	for _, i := range is.images {
+		images = append(images, i)
+	}
+
+	return images, nil
+}
+
+func (is *imageSvc) DeleteImage(ctx context.Context, name string) (err error) {
+	delete(is.images, name)
+	return nil
+}
+
+type container struct {
+	id    string
+	image node.Image
+	task  node.Task
+}
+
+func NewContainer(containerID string, i node.Image, t node.Task) node.Container {
+	return &container{
+		id:    containerID,
+		image: i,
+		task:  t,
+	}
+}
+
+func (c *container) ID() string {
+	return c.id
+}
+
+func (c *container) Image(ctx context.Context) (node.Image, error) {
+	return c.image, nil
+}
+
+func (c *container) Task(ctx context.Context, attach cio.Attach) (node.Task, error) {
+	return c.task, nil
+}
+
+type containerService struct {
+	containers map[string]node.Container
+}
+
+func NewContainerService(seedContainers map[string]node.Container) node.ContainerService {
+	return &containerService{
+		containers: seedContainers,
+	}
+}
+
+func (cs *containerService) CreateContainer(ctx context.Context, imageName string, id string) (container node.Container, err error) {
+	c := NewContainer(id, NewImage(imageName), nil)
+	cs.containers[id] = c
+	return c, nil
+}
+
+func (cs *containerService) GetContainer(ctx context.Context, id string) (container node.Container, err error) {
+	var containerValid bool
+
+	if container, containerValid = cs.containers[id]; !containerValid {
+		return nil, errors.New("invalid container")
+	}
+
+	return container, nil
+}
+
+func (cs *containerService) GetContainers(ctx context.Context, filter string) (containers []node.Container, err error) {
+
+	for _, c := range cs.containers {
+		containers = append(containers, c)
+	}
+
+	return containers, nil
+}
+
+func (cs *containerService) DeleteContainer(ctx context.Context, id string) (err error) {
+	delete(cs.containers, id)
+	return nil
+}
+
+type task struct {
+	id     string
+	pid    uint32
+	status node.Status
+	pids   []node.ProcessInfo
+}
+
+func NewTask(id string, pid uint32, status node.Status, pids []node.ProcessInfo) node.Task {
+	return &task{
+		id:     id,
+		pid:    pid,
+		status: status,
+		pids:   pids,
+	}
+}
+
+func (t *task) ID() string {
+	return t.id
+}
+
+func (t *task) Pid() uint32 {
+	return t.pid
+}
+
+func (t *task) Status(ctx context.Context, attach cio.Attach) (node.Status, error) {
+	return t.status, nil
+}
+
+func (t *task) Pids(ctx context.Context) ([]node.ProcessInfo, error) {
+	return t.pids, nil
+}
+
+type taskService struct {
+	tasks map[string]node.Task
+}
+
+func NewTaskService(seedTasks map[string]node.Task) node.TaskService {
+	return &taskService{
+		tasks: seedTasks,
+	}
+}
+
+func (ts *taskService) CreateTask(ctx context.Context, containerID string) (task node.Task, err error) {
+	t := NewTask(containerID, 1, node.Status{}, []node.ProcessInfo{})
+	ts.tasks[containerID] = t
+	return t, nil
+}
+
+func (ts *taskService) GetTask(ctx context.Context, containerID string) (task node.Task, err error) {
+	var taskValid bool
+
+	if task, taskValid = ts.tasks[containerID]; !taskValid {
+		return nil, errors.New("invalid task")
+	}
+
+	return task, nil
+}
+
+func (ts *taskService) GetTasks(ctx context.Context, filter string) (tasks []node.Task, err error) {
+
+	for _, t := range ts.tasks {
+		tasks = append(tasks, t)
+	}
+
+	return tasks, nil
+}
+
+func (ts *taskService) KillTask(ctx context.Context, containerID string) (err error) {
+	return nil
+}
+
+func (ts *taskService) DeleteTask(ctx context.Context, containerID string) (exitStatus node.ExitStatus, err error) {
+	delete(ts.tasks, containerID)
+	return node.ExitStatus{}, nil
+}
+
+var (
+	weirdString     = "@#%4$1^'`_|+%20"
+	testImage       = "docker.io/library/hello-world:latest"
+	seedImage       = "docker.io/library/nginx:latest"
+	testNamespace   = "clamor-testing"
+	testContainerID = "clamor-testing"
+)
+
+func TestNewImageResolver(t *testing.T) {
+	type resolverArgs struct {
+		resolveParamArgs map[string]interface{}
+	}
+
+	type imageResolverTest struct {
+		name    string
+		args    resolverArgs
+		wantErr bool
+	}
+
+	imageSvc := NewImageService(map[string]node.Image{
+		seedImage: NewImage(seedImage),
+	})
+
+	tests := []imageResolverTest{
+		{name: "empty namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": "", "ref": testImage}}, wantErr: true},
+		{name: "weird namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": weirdString, "ref": testImage}}, wantErr: true},
+		{name: "nil ref", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "ref": nil}}, wantErr: true},
+		{name: "weird ref", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "ref": weirdString}}, wantErr: true},
+		{name: "valid namespace valid ref", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "ref": seedImage}}, wantErr: false},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+			imageResolver := api.NewImageResolver(imageSvc)
+			i, err := imageResolver(graphql.ResolveParams{
+				Args: test.args.resolveParamArgs,
+			})
+
+			if err != nil && !test.wantErr {
+				t.Errorf("image resolver failed with error: " + err.Error())
+			}
+
+			if _, imgValid := i.(api.Image); !imgValid && !test.wantErr {
+				t.Errorf("image resolver returned incorrect type")
+			}
+		})
+	}
+}
+
+func TestNewImagesResolver(t *testing.T) {
+	type resolverArgs struct {
+		resolveParamArgs map[string]interface{}
+	}
+
+	type imageResolverTest struct {
+		name    string
+		args    resolverArgs
+		wantErr bool
+	}
+
+	imageSvc := NewImageService(map[string]node.Image{
+		seedImage: NewImage(seedImage),
+	})
+	tests := []imageResolverTest{
+		{name: "empty namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": "", "filter": nil}}, wantErr: true},
+		{name: "weird namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": weirdString, "filter": nil}}, wantErr: true},
+		{name: "weird filter", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "filter": weirdString}}, wantErr: true},
+		{name: "valid namespace nil filter", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "filter": nil}}, wantErr: false},
+	}
+
+	imageSvc.PullImage(context.TODO(), seedImage)
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+			imagesResolver := api.NewImagesResolver(imageSvc)
+			imgsRaw, err := imagesResolver(graphql.ResolveParams{
+				Args: test.args.resolveParamArgs,
+			})
+
+			if err != nil && !test.wantErr {
+				t.Errorf("image resolver failed with error: " + err.Error())
+			}
+
+			imgs, imgsValid := imgsRaw.([]interface{})
+
+			if imgsValid {
+
+				for _, img := range imgs {
+
+					if _, imgValid := img.(api.Image); !imgValid && !test.wantErr {
+						t.Errorf("images resolver returned incorrect type")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNewContainerResolver(t *testing.T) {
+	type resolverArgs struct {
+		resolveParamArgs map[string]interface{}
+	}
+
+	type imageResolverTest struct {
+		name    string
+		args    resolverArgs
+		wantErr bool
+	}
+
+	containerSvc := NewContainerService(map[string]node.Container{
+		testContainerID: NewContainer(testContainerID, NewImage(seedImage), NewTask(testContainerID, 1, node.Status{}, []node.ProcessInfo{})),
+	})
+	tests := []imageResolverTest{
+		{name: "empty namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": "", "id": testContainerID}}, wantErr: true},
+		{name: "weird namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": weirdString, "id": testContainerID}}, wantErr: true},
+		{name: "nil container name", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "id": nil}}, wantErr: true},
+		{name: "weird container name", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "id": weirdString}}, wantErr: true},
+		{name: "valid namespace valid container name", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "id": testContainerID}}, wantErr: false},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+			containerResolver := api.NewContainerResolver(containerSvc)
+			i, err := containerResolver(graphql.ResolveParams{
+				Args: test.args.resolveParamArgs,
+			})
+
+			if err != nil && !test.wantErr {
+				t.Errorf("container resolver failed with error: " + err.Error())
+			}
+
+			if _, containerValid := i.(api.Container); !containerValid && !test.wantErr {
+				t.Errorf("container resolver returned incorrect type")
+			}
+		})
+	}
+}
+
+func TestNewContainersResolver(t *testing.T) {
+	type resolverArgs struct {
+		resolveParamArgs map[string]interface{}
+	}
+
+	type containersResolverTest struct {
+		name    string
+		args    resolverArgs
+		wantErr bool
+	}
+
+	containerSvc := NewContainerService(map[string]node.Container{
+		testContainerID: NewContainer(testContainerID, NewImage(seedImage), NewTask(testContainerID, 1, node.Status{}, []node.ProcessInfo{})),
+	})
+	tests := []containersResolverTest{
+		{name: "empty namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": "", "filter": ""}}, wantErr: true},
+		{name: "weird namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": weirdString, "filter": ""}}, wantErr: true},
+		{name: "nil filter", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "filter": nil}}, wantErr: true},
+		{name: "weird filter", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "filter": weirdString}}, wantErr: true},
+		{name: "valid namespace valid filter", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "filter": ""}}, wantErr: false},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+			containersResolver := api.NewContainersResolver(containerSvc)
+			containersRaw, err := containersResolver(graphql.ResolveParams{
+				Args: test.args.resolveParamArgs,
+			})
+
+			if err != nil && !test.wantErr {
+				t.Errorf("containers resolver failed with error: " + err.Error())
+			}
+
+			containers, containersValid := containersRaw.([]interface{})
+
+			if containersValid {
+
+				for _, container := range containers {
+
+					if _, containerValid := container.(api.Container); !containerValid && !test.wantErr {
+						t.Errorf("containers resolver returned incorrect type")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNewTaskResolver(t *testing.T) {
+	type resolverArgs struct {
+		resolveParamArgs map[string]interface{}
+	}
+
+	type taskResolverTest struct {
+		name    string
+		args    resolverArgs
+		wantErr bool
+	}
+
+	taskSvc := NewTaskService(map[string]node.Task{
+		testContainerID: NewTask(testContainerID, 1, node.Status{}, []node.ProcessInfo{}),
+	})
+	tests := []taskResolverTest{
+		{name: "empty namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": "", "container_id": testContainerID}}, wantErr: true},
+		{name: "weird namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": weirdString, "container_id": testContainerID}}, wantErr: true},
+		{name: "nil container ID", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "container_id": nil}}, wantErr: true},
+		{name: "weird container ID", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "container_id": weirdString}}, wantErr: true},
+		{name: "valid namespace valid container ID", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "container_id": testContainerID}}, wantErr: false},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+			taskResolver := api.NewTaskResolver(taskSvc)
+			task, err := taskResolver(graphql.ResolveParams{
+				Args: test.args.resolveParamArgs,
+			})
+
+			if err != nil && !test.wantErr {
+				t.Errorf("task resolver failed with error: " + err.Error())
+			}
+
+			if _, taskValid := task.(api.Task); !taskValid && !test.wantErr {
+				t.Errorf("task resolver returned incorrect type")
+			}
+		})
+	}
+}
+
+func TestNewTasksResolver(t *testing.T) {
+	type resolverArgs struct {
+		resolveParamArgs map[string]interface{}
+	}
+
+	type tasksResolverTest struct {
+		name    string
+		args    resolverArgs
+		wantErr bool
+	}
+
+	taskSvc := NewTaskService(map[string]node.Task{
+		testContainerID: NewTask(testContainerID, 1, node.Status{}, []node.ProcessInfo{}),
+	})
+	tests := []tasksResolverTest{
+		{name: "empty namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": "", "filter": ""}}, wantErr: true},
+		{name: "weird namespace", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": weirdString, "filter": ""}}, wantErr: true},
+		{name: "nil filter", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "filter": nil}}, wantErr: true},
+		{name: "weird filter", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "filter": weirdString}}, wantErr: true},
+		{name: "valid namespace valid filter", args: resolverArgs{resolveParamArgs: map[string]interface{}{"namespace": testNamespace, "filter": ""}}, wantErr: false},
+	}
+
+	for _, test := range tests {
+
+		t.Run(test.name, func(t *testing.T) {
+			tasksResolver := api.NewTasksResolver(taskSvc)
+			tasksRaw, err := tasksResolver(graphql.ResolveParams{
+				Args: test.args.resolveParamArgs,
+			})
+
+			if err != nil && !test.wantErr {
+				t.Errorf("tasks resolver failed with error: " + err.Error())
+			}
+
+			tasks, tasksValid := tasksRaw.([]interface{})
+
+			if tasksValid {
+
+				for _, task := range tasks {
+
+					if _, taskValid := task.(api.Task); !taskValid && !test.wantErr {
+						t.Errorf("tasks resolver returned incorrect type")
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/node/container.go
+++ b/pkg/node/container.go
@@ -1,0 +1,39 @@
+package node
+
+import (
+	"context"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+)
+
+// Container wraps containerd.Container
+type Container interface {
+	ID() string
+	Image(context.Context) (Image, error)
+	Task(context.Context, cio.Attach) (Task, error)
+}
+
+func newContainer(c containerd.Container) Container {
+	return &container{
+		ctrContainer: c,
+	}
+}
+
+type container struct {
+	ctrContainer containerd.Container
+}
+
+func (c *container) ID() string {
+	return c.ctrContainer.ID()
+}
+
+func (c *container) Image(ctx context.Context) (Image, error) {
+	return c.ctrContainer.Image(ctx)
+}
+
+func (c *container) Task(ctx context.Context, attach cio.Attach) (Task, error) {
+	task, err := c.ctrContainer.Task(ctx, attach)
+
+	return newTask(task), err
+}

--- a/pkg/node/image.go
+++ b/pkg/node/image.go
@@ -1,0 +1,24 @@
+package node
+
+import (
+	"github.com/containerd/containerd"
+)
+
+// Image wraps containerd.Image
+type Image interface {
+	Name() string
+}
+
+func newImage(i containerd.Image) Image {
+	return &image{
+		ctrImage: i,
+	}
+}
+
+type image struct {
+	ctrImage containerd.Image
+}
+
+func (i *image) Name() string {
+	return i.ctrImage.Name()
+}

--- a/pkg/node/image.go
+++ b/pkg/node/image.go
@@ -9,7 +9,7 @@ type Image interface {
 	Name() string
 }
 
-func newImage(i containerd.Image) Image {
+func NewImage(i containerd.Image) Image {
 	return &image{
 		ctrImage: i,
 	}

--- a/pkg/node/image.go
+++ b/pkg/node/image.go
@@ -9,7 +9,7 @@ type Image interface {
 	Name() string
 }
 
-func NewImage(i containerd.Image) Image {
+func newImage(i containerd.Image) Image {
 	return &image{
 		ctrImage: i,
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -78,7 +78,7 @@ func TaskStatus(ctx context.Context, task Task) (status string) {
 // GetImage gets a containerd.Image instance by name.
 func (n Node) GetImage(ctx context.Context, name string) (i Image, err error) {
 	image, err := n.getImage(ctx, name)
-	return NewImage(image), err
+	return newImage(image), err
 }
 
 func (n Node) getImage(ctx context.Context, name string) (i containerd.Image, err error) {
@@ -144,7 +144,7 @@ func (n Node) CreateTask(ctx context.Context, containerID string) (t Task, err e
 // It returns the created containerd.Image.
 func (n Node) PullImage(ctx context.Context, ref string) (i Image, err error) {
 	image, err := n.pullImage(ctx, ref)
-	return NewImage(image), err
+	return newImage(image), err
 }
 
 func (n Node) pullImage(ctx context.Context, ref string) (image containerd.Image, err error) {
@@ -166,7 +166,7 @@ func (n Node) GetImages(ctx context.Context, filter string) (images []Image, err
 	}
 
 	for _, i := range imgs {
-		images = append(images, NewImage(i))
+		images = append(images, newImage(i))
 	}
 
 	return images, nil

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -2,7 +2,6 @@
 Package node provides interfaces for containerd interaction and clamor-node business logic.
 Right now it's mostly just a wrapper around https://pkg.go.dev/github.com/containerd/containerd?tab=doc#Client.
 TODO: Consider k8s container runtime interface support.
-TODO: Encapsulate containerd types somehow, may be dependent on the above.
 */
 package node
 
@@ -30,28 +29,28 @@ type Service interface {
 
 // ImageService provides methods to interact with containerd Image objects.
 type ImageService interface {
-	PullImage(ctx context.Context, name string) (image containerd.Image, err error)
-	GetImage(ctx context.Context, name string) (img containerd.Image, err error)
-	GetImages(ctx context.Context, filter string) (imgs []containerd.Image, err error)
+	PullImage(ctx context.Context, name string) (image Image, err error)
+	GetImage(ctx context.Context, name string) (image Image, err error)
+	GetImages(ctx context.Context, filter string) (images []Image, err error)
 	DeleteImage(ctx context.Context, name string) (err error)
 }
 
 // ContainerService provides methods to interact with containerd Container objects.
 type ContainerService interface {
-	CreateContainer(ctx context.Context, imageName, id string) (container containerd.Container, err error)
-	GetContainer(ctx context.Context, id string) (container containerd.Container, err error)
-	GetContainers(ctx context.Context, filter string) (container []containerd.Container, err error)
+	CreateContainer(ctx context.Context, imageName, id string) (container Container, err error)
+	GetContainer(ctx context.Context, id string) (container Container, err error)
+	GetContainers(ctx context.Context, filter string) (container []Container, err error)
 	DeleteContainer(ctx context.Context, id string) (err error)
 }
 
 // TaskService provides methods to interact with containerd Task objects.
 // Most operations are relative to their parent Container
 type TaskService interface {
-	CreateTask(ctx context.Context, containerID string) (task containerd.Task, err error)
-	GetTask(ctx context.Context, containerID string) (task containerd.Task, err error)
-	GetTasks(ctx context.Context, filter string) (tasks []containerd.Task, err error)
+	CreateTask(ctx context.Context, containerID string) (task Task, err error)
+	GetTask(ctx context.Context, containerID string) (task Task, err error)
+	GetTasks(ctx context.Context, filter string) (tasks []Task, err error)
 	KillTask(ctx context.Context, containerID string) (err error)
-	DeleteTask(ctx context.Context, containerID string) (exitStatus *containerd.ExitStatus, err error)
+	DeleteTask(ctx context.Context, containerID string) (exitStatus ExitStatus, err error)
 }
 
 // NewNode returns Node instances.
@@ -62,12 +61,12 @@ func NewNode(ctr *containerd.Client) *Node {
 }
 
 // TaskStatus returns the given containerd.Task's process status as a string.
-func TaskStatus(ctx context.Context, task containerd.Task) (status string) {
+func TaskStatus(ctx context.Context, task Task) (status string) {
 	if task == nil {
 		return ""
 	}
 
-	stats, statsErr := task.Status(ctx)
+	stats, statsErr := task.Status(ctx, nil)
 
 	if statsErr != nil {
 		return ""
@@ -77,11 +76,16 @@ func TaskStatus(ctx context.Context, task containerd.Task) (status string) {
 }
 
 // GetImage gets a containerd.Image instance by name.
-func (n Node) GetImage(ctx context.Context, name string) (image containerd.Image, err error) {
-	image, getImageErr := n.Ctr.GetImage(ctx, name)
+func (n Node) GetImage(ctx context.Context, name string) (i Image, err error) {
+	image, err := n.getImage(ctx, name)
+	return newImage(image), err
+}
 
-	if getImageErr != nil {
-		return nil, errors.New("GetImage: failed to get image " + name + " with error: " + getImageErr.Error())
+func (n Node) getImage(ctx context.Context, name string) (i containerd.Image, err error) {
+	image, err := n.Ctr.GetImage(ctx, name)
+
+	if err != nil {
+		return nil, errors.New("GetImage: failed to get image " + name + " with error: " + err.Error())
 	}
 
 	return image, nil
@@ -89,13 +93,14 @@ func (n Node) GetImage(ctx context.Context, name string) (image containerd.Image
 
 // CreateContainer creates a containerd.Container instance with the given id using the given image.
 // It returns the created containerd.Container.
-func (n Node) CreateContainer(ctx context.Context, imageName, id string) (container containerd.Container, err error) {
+func (n Node) CreateContainer(ctx context.Context, imageName, id string) (c Container, err error) {
 	var (
+		container              containerd.Container
 		image                  containerd.Image
 		getImageErr, createErr error
 	)
 
-	if image, getImageErr = n.PullImage(ctx, imageName); getImageErr != nil {
+	if image, getImageErr = n.pullImage(ctx, imageName); getImageErr != nil {
 		return nil, errors.New("Node failed to get image " + imageName + " with error: " + getImageErr.Error())
 	}
 
@@ -111,14 +116,15 @@ func (n Node) CreateContainer(ctx context.Context, imageName, id string) (contai
 		return nil, errors.New("Node failed to create container " + id + " with error: " + createErr.Error())
 	}
 
-	return container, nil
+	return newContainer(container), nil
 }
 
 // CreateTask starts a new task for the given container.
 // It returns the created containerd.Task.
 // TODO: Figure out task I/O. Currently just using stdio.
-func (n Node) CreateTask(ctx context.Context, containerID string) (task containerd.Task, err error) {
+func (n Node) CreateTask(ctx context.Context, containerID string) (t Task, err error) {
 	var (
+		task                        containerd.Task
 		container, loadContainerErr = n.Ctr.LoadContainer(ctx, containerID)
 		newTaskErr                  error
 	)
@@ -131,12 +137,17 @@ func (n Node) CreateTask(ctx context.Context, containerID string) (task containe
 		return nil, errors.New("Node failed to create task with error: " + newTaskErr.Error())
 	}
 
-	return task, nil
+	return newTask(task), nil
 }
 
 // PullImage pulls the given image ref.
 // It returns the created containerd.Image.
-func (n Node) PullImage(ctx context.Context, ref string) (image containerd.Image, err error) {
+func (n Node) PullImage(ctx context.Context, ref string) (i Image, err error) {
+	image, err := n.pullImage(ctx, ref)
+	return newImage(image), err
+}
+
+func (n Node) pullImage(ctx context.Context, ref string) (image containerd.Image, err error) {
 	image, pullImageErr := n.Ctr.Pull(ctx, ref)
 
 	if pullImageErr != nil {
@@ -147,18 +158,27 @@ func (n Node) PullImage(ctx context.Context, ref string) (image containerd.Image
 }
 
 // GetImages returns a list of all containerd.Image instances known to the containerd daemon.
-func (n Node) GetImages(ctx context.Context, filter string) (imgs []containerd.Image, err error) {
-	images, getImagesErr := n.Ctr.ListImages(ctx, filter)
+func (n Node) GetImages(ctx context.Context, filter string) (images []Image, err error) {
+	imgs, getImagesErr := n.Ctr.ListImages(ctx, filter)
 
 	if getImagesErr != nil {
 		return nil, errors.New("GetImages: failed to get images using filter " + filter + " with error: " + getImagesErr.Error())
+	}
+
+	for _, i := range imgs {
+		images = append(images, newImage(i))
 	}
 
 	return images, nil
 }
 
 // GetContainer retrieves a containerd.Container instance by the given ID.
-func (n Node) GetContainer(ctx context.Context, containerID string) (container containerd.Container, err error) {
+func (n Node) GetContainer(ctx context.Context, containerID string) (c Container, err error) {
+	container, err := n.getContainer(ctx, containerID)
+	return newContainer(container), err
+}
+
+func (n Node) getContainer(ctx context.Context, containerID string) (c containerd.Container, err error) {
 	container, loadContainerErr := n.Ctr.LoadContainer(ctx, containerID)
 
 	if loadContainerErr != nil {
@@ -169,20 +189,29 @@ func (n Node) GetContainer(ctx context.Context, containerID string) (container c
 }
 
 // GetContainers returns a list of all containerd.Container instances known to the containerd daemon.
-func (n Node) GetContainers(ctx context.Context, filter string) (container []containerd.Container, err error) {
+func (n Node) GetContainers(ctx context.Context, filter string) (cs []Container, err error) {
 	containers, getContainersErr := n.Ctr.Containers(ctx, filter)
 
 	if getContainersErr != nil {
 		return nil, errors.New("GetImages: failed to get containers using filter " + filter + " with error: " + getContainersErr.Error())
 	}
 
-	return containers, nil
+	for _, c := range containers {
+		cs = append(cs, newContainer(c))
+	}
+
+	return cs, nil
 }
 
 // GetTask retrieves a containerd.Task instance for the given container ID.
 // TODO: Handle containers that don't have tasks. The below won't differentiate between errors retrieving a container task and taskless containers.
-func (n Node) GetTask(ctx context.Context, containerID string) (task containerd.Task, err error) {
-	container, getContainerErr := n.GetContainer(ctx, containerID)
+func (n Node) GetTask(ctx context.Context, containerID string) (t Task, err error) {
+	task, err := n.getTask(ctx, containerID)
+	return newTask(task), err
+}
+
+func (n Node) getTask(ctx context.Context, containerID string) (task containerd.Task, err error) {
+	container, getContainerErr := n.getContainer(ctx, containerID)
 
 	if getContainerErr != nil {
 		return nil, errors.New("GetTask: failed to load task for container " + containerID + " with error: " + getContainerErr.Error())
@@ -198,7 +227,7 @@ func (n Node) GetTask(ctx context.Context, containerID string) (task containerd.
 }
 
 // GetTasks returns a list of all containerd.Task instances known to the containerd daemon.
-func (n Node) GetTasks(ctx context.Context, filter string) (tasks []containerd.Task, err error) {
+func (n Node) GetTasks(ctx context.Context, filter string) (tasks []Task, err error) {
 	containers, getContainersErr := n.Ctr.Containers(ctx, filter)
 
 	if getContainersErr != nil {
@@ -213,7 +242,7 @@ func (n Node) GetTasks(ctx context.Context, filter string) (tasks []containerd.T
 			continue
 		}
 
-		tasks = append(tasks, task)
+		tasks = append(tasks, newTask(task))
 	}
 
 	return tasks, nil
@@ -227,7 +256,7 @@ func (n Node) KillTask(ctx context.Context, containerID string) (err error) {
 		getTaskErr, killTaskErr error
 	)
 
-	if task, getTaskErr = n.GetTask(ctx, containerID); getTaskErr != nil {
+	if task, getTaskErr = n.getTask(ctx, containerID); getTaskErr != nil {
 		return errors.New("KillTask: failed to get container " + containerID + " with error: " + getTaskErr.Error())
 	}
 
@@ -259,20 +288,20 @@ func (n Node) DeleteContainer(ctx context.Context, id string) (err error) {
 }
 
 // DeleteTask deletes resources associated with the given container's task.
-func (n Node) DeleteTask(ctx context.Context, containerID string) (exitStatus *containerd.ExitStatus, err error) {
+func (n Node) DeleteTask(ctx context.Context, containerID string) (exitStatus ExitStatus, err error) {
 	var (
 		task                      containerd.Task
 		taskExitStatus            *containerd.ExitStatus
 		getTaskErr, deleteTaskErr error
 	)
 
-	if task, getTaskErr = n.GetTask(ctx, containerID); getTaskErr != nil {
-		return nil, errors.New("DeleteTask: failed to get task for container " + containerID + " with error: " + getTaskErr.Error())
+	if task, getTaskErr = n.getTask(ctx, containerID); getTaskErr != nil {
+		return ExitStatus{}, errors.New("DeleteTask: failed to get task for container " + containerID + " with error: " + getTaskErr.Error())
 	}
 
 	if taskExitStatus, deleteTaskErr = task.Delete(ctx); deleteTaskErr != nil {
-		return nil, errors.New("DeleteTask: failed to delete task for container " + containerID + " with error: " + deleteTaskErr.Error())
+		return ExitStatus{}, errors.New("DeleteTask: failed to delete task for container " + containerID + " with error: " + deleteTaskErr.Error())
 	}
 
-	return taskExitStatus, nil
+	return ExitStatus(*taskExitStatus), nil
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -78,7 +78,7 @@ func TaskStatus(ctx context.Context, task Task) (status string) {
 // GetImage gets a containerd.Image instance by name.
 func (n Node) GetImage(ctx context.Context, name string) (i Image, err error) {
 	image, err := n.getImage(ctx, name)
-	return newImage(image), err
+	return NewImage(image), err
 }
 
 func (n Node) getImage(ctx context.Context, name string) (i containerd.Image, err error) {
@@ -144,7 +144,7 @@ func (n Node) CreateTask(ctx context.Context, containerID string) (t Task, err e
 // It returns the created containerd.Image.
 func (n Node) PullImage(ctx context.Context, ref string) (i Image, err error) {
 	image, err := n.pullImage(ctx, ref)
-	return newImage(image), err
+	return NewImage(image), err
 }
 
 func (n Node) pullImage(ctx context.Context, ref string) (image containerd.Image, err error) {
@@ -166,7 +166,7 @@ func (n Node) GetImages(ctx context.Context, filter string) (images []Image, err
 	}
 
 	for _, i := range imgs {
-		images = append(images, newImage(i))
+		images = append(images, NewImage(i))
 	}
 
 	return images, nil

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,0 +1,586 @@
+package node_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+	"github.com/mokrz/clamor/pkg/node"
+)
+
+var (
+	containerdSock  = "/run/containerd/containerd.sock"
+	weirdString     = "@#%4$1^'`_|+%20"
+	testImage       = "docker.io/library/hello-world:latest"
+	testNamespace   = "clamor-testing"
+	testContainerID = "clamor-testing"
+	ctr             *containerd.Client
+)
+
+func TestPullImage(t *testing.T) {
+	type testArguments struct {
+		namespace, imageName string
+	}
+
+	type test struct {
+		name             string
+		args             testArguments
+		wantErr, wantImg bool
+	}
+
+	tests := []test{
+		{name: "empty namespace", args: testArguments{namespace: "", imageName: testImage}, wantErr: true},
+		{name: "weird namespace", args: testArguments{namespace: weirdString, imageName: testImage}, wantErr: true},
+		{name: "empty image name", args: testArguments{namespace: testNamespace, imageName: ""}, wantErr: true},
+		{name: "weird image name", args: testArguments{namespace: testNamespace, imageName: weirdString}, wantErr: true},
+		{name: "valid namespace valid image name", args: testArguments{namespace: testNamespace, imageName: testImage}, wantErr: false},
+	}
+
+	ctrd, ctrdErr := newCtrd(containerdSock)
+	defer ctrd.client.Close()
+
+	if ctrdErr != nil {
+		t.Errorf("failed to create containerd client with error: %s", ctrdErr.Error())
+	}
+
+	node := node.NewNode(ctrd.client)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := namespaces.WithNamespace(context.TODO(), test.args.namespace)
+			i, err := node.PullImage(ctx, test.args.imageName)
+
+			if i != nil {
+				ctrd.deleteImage(ctx, i.Name())
+			} else if !test.wantErr {
+				t.Errorf("node.PullImage failed with error: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestGetImage(t *testing.T) {
+	type testArguments struct {
+		namespace, imageName string
+	}
+
+	type test struct {
+		name             string
+		args             testArguments
+		wantErr, wantImg bool
+	}
+
+	tests := []test{
+		{name: "empty namespace", args: testArguments{namespace: "", imageName: testImage}, wantErr: true},
+		{name: "weird namespace", args: testArguments{namespace: weirdString, imageName: testImage}, wantErr: true},
+		{name: "empty image name", args: testArguments{namespace: testNamespace, imageName: ""}, wantErr: true},
+		{name: "weird image name", args: testArguments{namespace: testNamespace, imageName: weirdString}, wantErr: true},
+		{name: "valid namespace valid image name", args: testArguments{namespace: testNamespace, imageName: testImage}, wantErr: false},
+	}
+
+	ctrd, ctrdErr := newCtrd(containerdSock)
+	defer ctrd.client.Close()
+
+	if ctrdErr != nil {
+		t.Errorf("failed to create containerd client with error: %s", ctrdErr.Error())
+	}
+
+	node := node.NewNode(ctrd.client)
+	ctx := namespaces.WithNamespace(context.TODO(), testNamespace)
+
+	_, pullErr := ctrd.pullImage(ctx, testImage)
+
+	if pullErr != nil {
+		t.Errorf("failed to pull seed image with error: %s", pullErr)
+	}
+
+	defer ctrd.deleteImage(ctx, testImage)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := node.GetImage(namespaces.WithNamespace(context.TODO(), test.args.namespace), test.args.imageName)
+
+			if err != nil && !test.wantErr {
+				t.Errorf("node.GetImage failed with error: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestCreateContainer(t *testing.T) {
+	type testArguments struct {
+		namespace, image, id string
+	}
+
+	type test struct {
+		name             string
+		args             testArguments
+		wantErr, wantImg bool
+	}
+
+	tests := []test{
+		{name: "empty namespace", args: testArguments{namespace: "", image: testImage, id: testContainerID}, wantErr: true},
+		{name: "weird namespace", args: testArguments{namespace: weirdString, image: testImage, id: testContainerID}, wantErr: true},
+		{name: "empty image name", args: testArguments{namespace: testNamespace, image: "", id: ""}, wantErr: true},
+		{name: "weird image name", args: testArguments{namespace: testNamespace, image: weirdString, id: weirdString}, wantErr: true},
+		{name: "empty container ID", args: testArguments{namespace: testNamespace, image: testImage, id: ""}, wantErr: true},
+		{name: "weird container ID", args: testArguments{namespace: testNamespace, image: testImage, id: weirdString}, wantErr: true},
+		{name: "valid namespace valid image valid container ID", args: testArguments{namespace: testNamespace, image: testImage, id: testContainerID}, wantErr: false},
+	}
+
+	ctrd, ctrdErr := newCtrd(containerdSock)
+	defer ctrd.client.Close()
+
+	if ctrdErr != nil {
+		t.Errorf("failed to create containerd client with error: %s", ctrdErr.Error())
+	}
+
+	node := node.NewNode(ctrd.client)
+
+	ctx := namespaces.WithNamespace(context.TODO(), testNamespace)
+
+	_, pullErr := ctrd.pullImage(ctx, testImage)
+
+	if pullErr != nil {
+		t.Errorf("failed to pull seed image with error: %s", pullErr.Error())
+	}
+
+	defer ctrd.deleteImage(ctx, testImage)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := namespaces.WithNamespace(context.TODO(), test.args.namespace)
+
+			_, err := node.CreateContainer(ctx, test.args.image, test.args.id)
+
+			if err != nil && !test.wantErr {
+				t.Errorf("node.CreateContainer failed with error: %s", err.Error())
+			}
+
+			ctrd.deleteContainer(ctx, test.args.id)
+		})
+	}
+}
+
+func TestCreateTask(t *testing.T) {
+	type testArguments struct {
+		namespace, containerID string
+	}
+
+	type test struct {
+		name             string
+		args             testArguments
+		wantErr, wantImg bool
+	}
+
+	tests := []test{
+		{name: "empty namespace", args: testArguments{namespace: "", containerID: testContainerID}, wantErr: true},
+		{name: "weird namespace", args: testArguments{namespace: weirdString, containerID: testContainerID}, wantErr: true},
+		{name: "empty container ID", args: testArguments{namespace: testNamespace, containerID: ""}, wantErr: true},
+		{name: "weird container ID", args: testArguments{namespace: testNamespace, containerID: weirdString}, wantErr: true},
+		{name: "valid namespace valid container ID", args: testArguments{namespace: testNamespace, containerID: testContainerID}, wantErr: false},
+	}
+
+	ctrd, ctrdErr := newCtrd(containerdSock)
+	defer ctrd.client.Close()
+
+	if ctrdErr != nil {
+		t.Errorf("failed to create containerd client with error: %s", ctrdErr.Error())
+	}
+
+	node := node.NewNode(ctrd.client)
+
+	ctx := namespaces.WithNamespace(context.TODO(), testNamespace)
+
+	_, pullErr := ctrd.pullImage(ctx, testImage)
+
+	if pullErr != nil {
+		t.Errorf("failed to pull seed image with error: %s", pullErr.Error())
+	}
+
+	defer ctrd.deleteImage(ctx, testImage)
+
+	_, createContainerErr := ctrd.createContainer(namespaces.WithNamespace(context.TODO(), testNamespace), testImage, testContainerID)
+
+	if createContainerErr != nil {
+		t.Errorf("failed to create seed container with error: %s", createContainerErr.Error())
+	}
+
+	defer ctrd.deleteContainer(ctx, testContainerID)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := namespaces.WithNamespace(context.TODO(), test.args.namespace)
+
+			if tsk, err := node.CreateTask(ctx, test.args.containerID); err != nil && !test.wantErr {
+				ctrd.deleteContainer(ctx, test.args.containerID)
+				t.Errorf("node.CreateTask failed with error: %s", err.Error())
+			} else if tsk != nil {
+				ctrd.killTask(ctx, tsk.ID())
+				ctrd.deleteTask(ctx, tsk.ID())
+			}
+		})
+	}
+}
+
+func TestKillTask(t *testing.T) {
+	type testArguments struct {
+		namespace, containerID string
+	}
+
+	type test struct {
+		name             string
+		args             testArguments
+		wantErr, wantImg bool
+	}
+
+	tests := []test{
+		{name: "empty namespace", args: testArguments{namespace: "", containerID: testContainerID}, wantErr: true},
+		{name: "weird namespace", args: testArguments{namespace: weirdString, containerID: testContainerID}, wantErr: true},
+		{name: "empty container ID", args: testArguments{namespace: testNamespace, containerID: ""}, wantErr: true},
+		{name: "weird container ID", args: testArguments{namespace: testNamespace, containerID: weirdString}, wantErr: true},
+		{name: "valid namespace valid container ID", args: testArguments{namespace: testNamespace, containerID: testContainerID}, wantErr: false},
+	}
+
+	ctrd, ctrdErr := newCtrd(containerdSock)
+	defer ctrd.client.Close()
+
+	if ctrdErr != nil {
+		t.Errorf("failed to create containerd client with error: %s", ctrdErr.Error())
+	}
+
+	node := node.NewNode(ctrd.client)
+
+	ctx := namespaces.WithNamespace(context.TODO(), testNamespace)
+
+	_, pullErr := ctrd.pullImage(ctx, testImage)
+
+	if pullErr != nil {
+		t.Errorf("failed to pull seed image with error: %s", pullErr.Error())
+	}
+
+	defer ctrd.deleteImage(ctx, testImage)
+
+	_, createContainerErr := ctrd.createContainer(namespaces.WithNamespace(context.TODO(), testNamespace), testImage, testContainerID)
+
+	if createContainerErr != nil {
+		t.Errorf("failed to create seed container with error: %s", createContainerErr.Error())
+	}
+
+	defer ctrd.deleteContainer(ctx, testContainerID)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrd.createTask(ctx, test.args.containerID)
+			err := node.KillTask(namespaces.WithNamespace(context.TODO(), test.args.namespace), test.args.containerID)
+
+			if err == nil {
+				ctrd.deleteTask(ctx, test.args.containerID)
+			} else if !test.wantErr {
+				t.Errorf("node.KillTask failed with error: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestDeleteTask(t *testing.T) {
+	type testArguments struct {
+		namespace, containerID string
+	}
+
+	type test struct {
+		name             string
+		args             testArguments
+		wantErr, wantImg bool
+	}
+
+	tests := []test{
+		{name: "empty namespace", args: testArguments{namespace: "", containerID: testContainerID}, wantErr: true},
+		{name: "weird namespace", args: testArguments{namespace: weirdString, containerID: testContainerID}, wantErr: true},
+		{name: "empty container ID", args: testArguments{namespace: testNamespace, containerID: ""}, wantErr: true},
+		{name: "weird container ID", args: testArguments{namespace: testNamespace, containerID: weirdString}, wantErr: true},
+		{name: "valid namespace valid container ID", args: testArguments{namespace: testNamespace, containerID: testContainerID}, wantErr: false},
+	}
+
+	ctrd, ctrdErr := newCtrd(containerdSock)
+	defer ctrd.client.Close()
+
+	if ctrdErr != nil {
+		t.Errorf("failed to create containerd client with error: %s", ctrdErr.Error())
+	}
+
+	node := node.NewNode(ctrd.client)
+
+	_, createContainerErr := ctrd.createContainer(namespaces.WithNamespace(context.TODO(), testNamespace), testImage, testContainerID)
+
+	if createContainerErr != nil {
+		t.Errorf("failed to create containerd client with error: %s", createContainerErr.Error())
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := namespaces.WithNamespace(context.TODO(), test.args.namespace)
+			ctrd.createTask(ctx, testContainerID)
+			ctrd.killTask(ctx, testContainerID)
+			_, err := node.DeleteTask(ctx, test.args.containerID)
+
+			if err != nil && !test.wantErr {
+				t.Errorf("node.KillTask failed with error: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestDeleteContainer(t *testing.T) {
+	type testArguments struct {
+		namespace, containerID string
+	}
+
+	type test struct {
+		name             string
+		args             testArguments
+		wantErr, wantImg bool
+	}
+
+	tests := []test{
+		{name: "empty namespace", args: testArguments{namespace: "", containerID: testContainerID}, wantErr: true},
+		{name: "weird namespace", args: testArguments{namespace: weirdString, containerID: testContainerID}, wantErr: true},
+		{name: "empty container ID", args: testArguments{namespace: testNamespace, containerID: ""}, wantErr: true},
+		{name: "weird container ID", args: testArguments{namespace: testNamespace, containerID: weirdString}, wantErr: true},
+		{name: "valid namespace valid container ID", args: testArguments{namespace: testNamespace, containerID: testContainerID}, wantErr: false},
+	}
+
+	ctrd, ctrdErr := newCtrd(containerdSock)
+	defer ctrd.client.Close()
+
+	if ctrdErr != nil {
+		t.Errorf("failed to create containerd client with error: %s", ctrdErr.Error())
+	}
+
+	node := node.NewNode(ctrd.client)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := namespaces.WithNamespace(context.TODO(), test.args.namespace)
+			ctrd.createContainer(ctx, testImage, testContainerID)
+			err := node.DeleteContainer(ctx, test.args.containerID)
+
+			if err != nil && !test.wantErr {
+				t.Errorf("node.DeleteContainer failed with error: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestDeleteImage(t *testing.T) {
+	type testArguments struct {
+		namespace, imageName string
+	}
+
+	type test struct {
+		name             string
+		args             testArguments
+		wantErr, wantImg bool
+	}
+
+	tests := []test{
+		{name: "empty namespace", args: testArguments{namespace: "", imageName: testImage}, wantErr: true},
+		{name: "weird namespace", args: testArguments{namespace: weirdString, imageName: testImage}, wantErr: true},
+		{name: "empty image name", args: testArguments{namespace: testNamespace, imageName: ""}, wantErr: true},
+		{name: "weird image name", args: testArguments{namespace: testNamespace, imageName: weirdString}, wantErr: true},
+		{name: "valid namespace valid image name", args: testArguments{namespace: testNamespace, imageName: testImage}, wantErr: false},
+	}
+
+	ctrd, ctrdErr := newCtrd(containerdSock)
+	defer ctrd.client.Close()
+
+	if ctrdErr != nil {
+		t.Errorf("failed to create containerd client with error: %s", ctrdErr.Error())
+	}
+
+	node := node.NewNode(ctrd.client)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := namespaces.WithNamespace(context.TODO(), test.args.namespace)
+			ctrd.pullImage(ctx, testImage)
+
+			err := node.DeleteImage(ctx, test.args.imageName)
+
+			if err != nil && !test.wantErr {
+				t.Errorf("node.DeleteImage failed with error: %s", err.Error())
+			}
+		})
+	}
+}
+
+// ctrd is similar to the containerd interaction provided by node.Service methods, but it's meant to be a simpler implementation that's easier to trust.
+// node.Service tests should use these methods to create SUT dependencies instead of whatever their closest node.Service relative is.
+// e.g. A test for node.CreateTask could use the below ctrd.createContainer method to populate the containerd daemon with the required container prior to task creation.
+
+type ctrd struct {
+	client *containerd.Client
+}
+
+func newCtrd(containerdPath string) (*ctrd, error) {
+	var (
+		ctr    *containerd.Client
+		ctrErr error
+	)
+
+	if ctr, ctrErr = containerd.New(containerdPath); ctrErr != nil {
+		return nil, ctrErr
+	}
+
+	return &ctrd{
+		client: ctr,
+	}, nil
+}
+
+func (c *ctrd) pullImage(ctx context.Context, imageName string) (containerd.Image, error) {
+	var (
+		image        containerd.Image
+		pullImageErr error
+	)
+
+	image, pullImageErr = c.client.Pull(ctx, imageName, containerd.WithPullUnpack)
+
+	if pullImageErr != nil {
+		return nil, fmt.Errorf("failed to pull image ref %s with error: %s", imageName, pullImageErr.Error())
+	}
+
+	return image, nil
+}
+
+func (c *ctrd) createContainer(ctx context.Context, imageName, id string) (containerd.Container, error) {
+	var (
+		image   containerd.Image
+		pullErr error
+	)
+
+	if image, pullErr = c.client.Pull(ctx, imageName, containerd.WithPullUnpack); pullErr != nil {
+		return nil, fmt.Errorf("failed to pull image ref %s with error: %s", imageName, pullErr.Error())
+	}
+
+	return c.client.NewContainer(
+		ctx,
+		id,
+		containerd.WithImage(image),
+		containerd.WithNewSnapshot(id, image),
+		containerd.WithNewSpec(oci.WithImageConfig(image)),
+	)
+}
+
+func (c *ctrd) getContainer(ctx context.Context, id string) (containerd.Container, error) {
+	container, loadContainerErr := c.client.LoadContainer(ctx, id)
+
+	if loadContainerErr != nil {
+		return nil, fmt.Errorf("failed to load container %s with error: %s", id, loadContainerErr.Error())
+	}
+
+	return container, nil
+}
+
+func (c *ctrd) deleteContainer(ctx context.Context, id string) error {
+	var (
+		container    containerd.Container
+		containerErr error
+	)
+
+	if container, containerErr = c.client.LoadContainer(ctx, id); containerErr != nil {
+		return fmt.Errorf("failed to load container with error: %s", containerErr.Error())
+	}
+
+	return container.Delete(ctx, containerd.WithSnapshotCleanup)
+}
+
+func (c *ctrd) createTask(ctx context.Context, containerID string) (containerd.Task, error) {
+	var (
+		task                         containerd.Task
+		container                    containerd.Container
+		loadContainerErr, newTaskErr error
+	)
+
+	if container, loadContainerErr = c.client.LoadContainer(ctx, containerID); loadContainerErr != nil {
+		return nil, fmt.Errorf("Node failed to load container %s with error: %s", containerID, loadContainerErr.Error())
+	}
+
+	if task, newTaskErr = container.NewTask(ctx, cio.NewCreator(cio.WithStdio)); newTaskErr != nil {
+		return nil, fmt.Errorf("Node failed to create task with error: %s", newTaskErr.Error())
+	}
+
+	return task, nil
+}
+
+func (c *ctrd) killTask(ctx context.Context, containerID string) error {
+	var (
+		task                    containerd.Task
+		getTaskErr, killTaskErr error
+	)
+
+	if task, getTaskErr = c.getTask(ctx, containerID); getTaskErr != nil {
+		return fmt.Errorf("failed to get container with error: %s", getTaskErr.Error())
+	}
+
+	if killTaskErr = task.Kill(ctx, syscall.SIGKILL); killTaskErr != nil {
+		return fmt.Errorf("failed to kill task for container %s with error: %s", containerID, killTaskErr.Error())
+	}
+
+	return killTaskErr
+}
+
+func (c *ctrd) deleteTask(ctx context.Context, containerID string) error {
+	var (
+		container                               containerd.Container
+		task                                    containerd.Task
+		getContainerErr, taskErr, deleteTaskErr error
+	)
+
+	if container, getContainerErr = c.client.LoadContainer(ctx, containerID); getContainerErr != nil {
+		return fmt.Errorf("failed to load task for container %s with error: %s", containerID, getContainerErr.Error())
+	}
+
+	if task, taskErr = container.Task(ctx, nil); taskErr != nil {
+		return fmt.Errorf("failed to load task for container %s with error: %s", containerID, taskErr.Error())
+	}
+
+	if _, deleteTaskErr = task.Delete(ctx); deleteTaskErr != nil {
+		return fmt.Errorf("failed to delete task for container %s with error: %s", containerID, deleteTaskErr.Error())
+	}
+
+	return nil
+}
+
+func (c *ctrd) deleteImage(ctx context.Context, name string) error {
+	var (
+		getImageErr, deleteImageErr error
+	)
+
+	if deleteImageErr = c.client.ImageService().Delete(ctx, name); deleteImageErr != nil {
+		return fmt.Errorf("failed to get image with error: %s", getImageErr.Error())
+	}
+
+	return nil
+}
+
+func (c *ctrd) getTask(ctx context.Context, containerID string) (containerd.Task, error) {
+	container, getContainerErr := c.getContainer(ctx, containerID)
+
+	if getContainerErr != nil {
+		return nil, errors.New("GetTask: failed to load task for container " + containerID + " with error: " + getContainerErr.Error())
+	}
+
+	task, taskErr := container.Task(ctx, nil)
+
+	if taskErr != nil {
+		return nil, errors.New("GetTask: failed to load task for container " + containerID + " with error: " + taskErr.Error())
+	}
+
+	return task, nil
+}

--- a/pkg/node/task.go
+++ b/pkg/node/task.go
@@ -1,0 +1,58 @@
+package node
+
+import (
+	"context"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+)
+
+// ExitStatus wraps containerd.ExitStatus
+type ExitStatus containerd.ExitStatus
+
+// Status wraps containerd.Status
+type Status containerd.Status
+
+// ProcessInfo wraps containerd.ProcessInfo
+type ProcessInfo containerd.ProcessInfo
+
+// Task wraps containerd.Task
+type Task interface {
+	ID() string
+	Pid() uint32
+	Status(ctx context.Context, attach cio.Attach) (Status, error)
+	Pids(ctx context.Context) ([]ProcessInfo, error)
+}
+
+func newTask(c containerd.Task) Task {
+	return &task{
+		ctrTask: c,
+	}
+}
+
+type task struct {
+	ctrTask containerd.Task
+}
+
+func (t *task) ID() string {
+	return t.ctrTask.ID()
+}
+
+func (t *task) Pid() uint32 {
+	return t.ctrTask.Pid()
+}
+
+func (t *task) Status(ctx context.Context, attach cio.Attach) (Status, error) {
+	stat, err := t.ctrTask.Status(ctx)
+	return Status(stat), err
+}
+
+func (t *task) Pids(ctx context.Context) (pis []ProcessInfo, err error) {
+	infos, err := t.ctrTask.Pids(ctx)
+
+	for _, pi := range infos {
+		pis = append(pis, ProcessInfo(pi))
+	}
+
+	return pis, err
+}


### PR DESCRIPTION
This pull request adds basic testing for GraphQL resolvers and `node.Service` methods. It also refactors symbol exposure and interface composition to make things more testable.

Changes include:

- `node.Service` is now composed of smaller subinterfaces.
- GraphQL resolvers accept these narrower implementations in place of their full `node.Service` dependencies.
- `node.Service` methods no longer expose containerd API types. Instead, they're wrapped in proxy interfaces for easier implementation.

GraphQL Resolvers are tested with faked dependencies, while `node.Service` tests require a full [containerd client](https://pkg.go.dev/github.com/containerd/containerd?tab=doc#Client), preferably backed by a real daemon.